### PR TITLE
allow partial substate modification

### DIFF
--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -16,9 +16,9 @@ export function stateReconciler(state, inboundState, reducedState, logger) {
 
    // otherwise take the inboundState
    if (state.has(key)) {
-     newState = state.merge(inboundState) // shallow merge
+     newState = newState.mergeIn([key], inboundState[key]) // shallow merge
    } else {
-     newState = state.set(key, inboundState[key]) // hard set
+     newState = newState.set(key, inboundState[key]) // hard set
    }
 
    if (logger) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])


### PR DESCRIPTION
This fixes an issue I'm having at the moment where my reducer modifies part of the incomingState but not every single key. The moment a key that hasn't been modified gets found we currently throw away any previous updates we've made to newState by merging state and inboundState.
