### PR TITLE
allow keys in the inbound state to be added

### DIFF
--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -4,9 +4,6 @@ export function stateReconciler(state, inboundState, reducedState, logger) {
  let newState = reducedState ? reducedState : new Map()
 
  Object.keys(inboundState).forEach((key) => {
-   // if initialState does not have key, skip auto rehydration
-   if (!state.has(key)) return
-
    // if reducer modifies substate, skip auto rehydration
    if (state.get(key) !== reducedState.get(key)) {
      if (logger) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)


### PR DESCRIPTION
don't require keys in the inbound state to be present in the current state.  this allows keys that are added in the inbound state (such as keys from redux-persist-migrate) to be added and persisted.

Take a look at https://github.com/rt2zz/redux-persist-immutable/issues/19 for some extra context.