### PR TITLE
update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A wrapper around redux-persist that provides  [ImmutableJS](https://facebook.git
 # Usage
 For entire api see [redux-persist docs](https://github.com/rt2zz/redux-persist). This library is a drop in replacement.
 ```js
-import { persistStore } from 'redux-persist-immutable'
+import { persistStore, autoRehydrate } from 'redux-persist-immutable'
 
-persistStore(state)
+persistStore(store)
 ```
 
 # Immutable records


### PR DESCRIPTION
make it clear that both `autoRehydrate` and `persistStore` must be imported from this mod to make it work. 

otherwise someone may think that official redux-persist example should be updated to include only custom `autoRehydrate` ... 

Hopefully it will save someone time of trial and error and frustration