### PR TITLE
stateReconciler is always overridden with default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const extendConfig = (config) => {
   let incomingTransforms = config.transforms || []
   let records = config.records || null
   let transforms = [...incomingTransforms, immutableTransform({ records })]
-  return {...config, ...operators, stateReconciler, transforms}
+  return {stateReconciler, ...config, ...operators, transforms}
 }
 
 const autoRehydrate = (config = {}, ...args) => {


### PR DESCRIPTION
The `extendConfig` function doesn't allow stateReconciler to be specified in the config. It is currently always overridden by the default.