### PR TITLE
logger incorrectly prints rehydrated to undefined

### DIFF
--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -1,7 +1,7 @@
 import { Map } from 'immutable';
 
 export function stateReconciler(state, inboundState, reducedState, logger) {
- let newState = reducedState ? reducedState : new Map()
+ let newState = reducedState ? reducedState : Map()
 
  Object.keys(inboundState).forEach((key) => {
    // if initialState does not have key, skip auto rehydration
@@ -21,7 +21,7 @@ export function stateReconciler(state, inboundState, reducedState, logger) {
      newState = newState.set(key, inboundState[key]) // hard set
    }
 
-   if (logger) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])
+   if (logger) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState.get(key))
  })
 
  return newState


### PR DESCRIPTION
newState is not a plain js object, it's an `immutable.Map`. Previously it would print `undefined` when in fact it was correctly rehydrated to part of the state.

I also removed `new` from the immutable Map creation. This isn't required as it's a factory.