### PR TITLE
Skip Immutable Transform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,10 @@ import { stateReconciler } from './reconciler'
 const extendConfig = (config) => {
   let incomingTransforms = config.transforms || []
   let records = config.records || null
-  let transforms = [...incomingTransforms, immutableTransform({ records })]
+  let transforms = incomingTransforms;
+  if (!config.skipImmutableTransform) {
+    transforms = [...incomingTransforms, immutableTransform({ records })]
+  }
   return {stateReconciler, ...config, ...operators, transforms}
 }
 


### PR DESCRIPTION
Library will no longer add the immutable transform to your config transforms array if 'skipImmutableTransform' in config is true.

Discussion in #31.