### PR TITLE
update redux-persist-transform-immutable to v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "redux-persist": "^4.0.0",
-    "redux-persist-transform-immutable": "^4.1.0"
+    "redux-persist-transform-immutable": "^5.0.0"
   },
   "peerDependencies": {
     "immutable": "*"


### PR DESCRIPTION
from the README of redux-persist-transform-immutable: 

`v5 changes from transitjs to remotedev-serialize. For existing projects that upgrade to v5, all persisted data will be lost upon the initial persist.`

transitjs is relatively big in size, so it would be nice to have a smaller bundle for `redux-persist-transform`.